### PR TITLE
Remove unnecessary 'Testsuite: autopkgtest' header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openbox-menu (0.8.0+hg20161009-2) UNRELEASED; urgency=medium
+
+  * Remove unnecessary 'Testsuite: autopkgtest' header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 14:15:19 +0100
+
 openbox-menu (0.8.0+hg20161009-1) unstable; urgency=medium
 
   [ Helmut Grohne ]

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Standards-Version: 4.0.1
 Homepage: https://bitbucket.org/fabriceT/openbox-menu
 Vcs-Browser: https://github.com/mati75/openbox-menu.git
 Vcs-Git: https://github.com/mati75/openbox-menu.git
-Testsuite: autopkgtest
 
 Package: openbox-menu
 Architecture: any


### PR DESCRIPTION
Remove unnecessary 'Testsuite: autopkgtest' header.

Fixes lintian: unnecessary-testsuite-autopkgtest-field
See https://lintian.debian.org/tags/unnecessary-testsuite-autopkgtest-field.html for more details.
