### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ openbox-menu (0.8.0+hg20161009-2) UNRELEASED; urgency=medium
   [ Debian Janitor ]
   * Use secure copyright file specification URI.
   * Bump debhelper from old 10 to 12.
+  * Trim trailing whitespace.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 14:15:19 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,8 @@ openbox-menu (0.8.0+hg20161009-2) UNRELEASED; urgency=medium
   * Use secure copyright file specification URI.
   * Bump debhelper from old 10 to 12.
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 14:15:19 +0100
 

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@ export DH_BUILD_MAINT_OPTIONS=nocheck
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ 
+	dh $@
 
 override_dh_auto_install:
 	$(MAKE) install BINDIR=$(CURDIR)/debian/openbox-menu/usr/bin

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/woho/openbox-menu/issues
+Bug-Submit: https://github.com/woho/openbox-menu/issues/new
+Repository: https://github.com/woho/openbox-menu.git
+Repository-Browse: https://github.com/woho/openbox-menu


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri.html))
* Bump debhelper from old 10 to 12. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version.html))
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbox-menu/a1f2f196-790f-4f70-898b-0657bb7d1f57.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a1f2f196-790f-4f70-898b-0657bb7d1f57/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a1f2f196-790f-4f70-898b-0657bb7d1f57/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a1f2f196-790f-4f70-898b-0657bb7d1f57/diffoscope)).
