### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openbox-menu (0.8.0+hg20161009-4) UNRELEASED; urgency=medium
+
+  * Remove unnecessary 'Testsuite: autopkgtest' header.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 06 Sep 2021 12:03:30 -0000
+
 openbox-menu (0.8.0+hg20161009-3) unstable; urgency=medium
 
   * Fix test running.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 openbox-menu (0.8.0+hg20161009-4) UNRELEASED; urgency=medium
 
   * Remove unnecessary 'Testsuite: autopkgtest' header.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 06 Sep 2021 12:03:30 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ openbox-menu (0.8.0+hg20161009-4) UNRELEASED; urgency=medium
   * Remove unnecessary 'Testsuite: autopkgtest' header.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 06 Sep 2021 12:03:30 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Standards-Version: 4.5.0
 Homepage: https://bitbucket.org/fabriceT/openbox-menu
 Vcs-Browser: https://github.com/mati75/openbox-menu.git
 Vcs-Git: https://github.com/mati75/openbox-menu.git
-Testsuite: autopkgtest
 
 Package: openbox-menu
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
 Build-Depends: debhelper-compat (= 13), libgtk2.0-dev, libmenu-cache-dev (>= 0.7), libglib2.0-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Homepage: https://bitbucket.org/fabriceT/openbox-menu
 Vcs-Browser: https://github.com/mati75/openbox-menu.git
 Vcs-Git: https://github.com/mati75/openbox-menu.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/woho/openbox-menu/issues
+Bug-Submit: https://github.com/woho/openbox-menu/issues/new
+Repository: https://github.com/woho/openbox-menu.git
+Repository-Browse: https://github.com/woho/openbox-menu


### PR DESCRIPTION
Fix some issues reported by lintian

* Remove unnecessary 'Testsuite: autopkgtest' header. ([unnecessary-testsuite-autopkgtest-field](https://lintian.debian.org/tags/unnecessary-testsuite-autopkgtest-field))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbox-menu/c831efa8-63f5-4b78-b27a-d61b64c18abb.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b3/914eb6a08551741775f5f4ceea7ba4c3aafc09.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ac/edffb6c516c1e37ac8ed82f774c6b10abb9b84.debug

No differences were encountered between the control files of package \*\*openbox-menu\*\*
### Control files of package openbox-menu-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-acedffb6c516c1e37ac8ed82f774c6b10abb9b84-] {+b3914eb6a08551741775f5f4ceea7ba4c3aafc09+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c831efa8-63f5-4b78-b27a-d61b64c18abb/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c831efa8-63f5-4b78-b27a-d61b64c18abb/diffoscope)).
